### PR TITLE
chore: add missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/node": "6.0.52",
     "ava": "0.17.0",
     "common-tags": "1.4.0",
+    "conventional-changelog-lint": "1.1.0",
     "coveralls": "2.11.15",
     "cz-conventional-changelog": "1.2.0",
     "cz-customizable": "4.0.0",


### PR DESCRIPTION
conventional-changelog-lint is required when commiting changes