### PR TITLE
chore(package): update source-map-support to version 0.4.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "lodash": "4.17.4",
     "nyc": "10.1.2",
     "rimraf": "2.6.1",
-    "source-map-support": "0.4.12",
+    "source-map-support": "0.4.14",
     "standard-version": "4.0.0",
     "tipi-cli": "3.1.0",
     "tslint": "4.5.1",


### PR DESCRIPTION
Closes #79

https://greenkeeper.io/